### PR TITLE
Fix filenames and quoting

### DIFF
--- a/configs/collect_metadata.config
+++ b/configs/collect_metadata.config
@@ -12,7 +12,7 @@ process {
                     '--subset_columns sample cram_path fastq_prefix sample_supplier_name library_type total_reads',
                     '--subset_file "metadata.csv"',
                     '--sep ","',
-                    '--subset_sep ";"',
+                    '--subset_sep ","',
                     '--sort_column "fastq_prefix"'
                 ].join(' ')
             }

--- a/main.nf
+++ b/main.nf
@@ -173,9 +173,9 @@ workflow {
         // Read CRAM metadata from file if specified and check if it contains all necessary columns
         crams = params.crams ? Channel.fromPath(params.crams, checkIfExists: true) : crams
         crams = crams
-            .splitCsv(header: true, sep: ',')
+            .splitCsv(header: true, sep: ',', quote: '"')
             .map { row -> 
-                if (row.fastq_prefix == null || row.fastq_prefix == '' || row.cram_path == null || row.cram_path == '') {
+                if (!row.containsKey('fastq_prefix') || row.fastq_prefix == null || row.fastq_prefix == '' || !row.containsKey('cram_path') || row.cram_path == null || row.cram_path == '') {
                     def row_string = row.collect { k, v -> "${k}:${v}" }.join(',')
                     error "CRAM metadata is missing 'fastq_prefix' or 'cram_path' for CRAM: ${row_string}"
                 }

--- a/modules/local/irods/getmetadata/main.nf
+++ b/modules/local/irods/getmetadata/main.nf
@@ -24,7 +24,7 @@ process IRODS_GETMETADATA {
     fi
 
     # Get metadata from iRODS
-    get_metadata.sh \$resource "${irodspath}" > metadata.tsv
+    get_metadata.sh \$resource "${irodspath}" | tr '"' "'" > metadata.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,7 +54,8 @@ process {
     queue  = 'normal'
     cpus   = 4
     memory = 2.GB
-    maxRetries = 3
+    maxRetries = 5
+    errorStrategy = { task.attempt == 5 ? "ignore" : "retry" }
 }
 
 workflow {

--- a/subworkflows/local/irods_findcrams/main.nf
+++ b/subworkflows/local/irods_findcrams/main.nf
@@ -1,6 +1,6 @@
-include { IRODS_FIND } from '../../../modules/local/irods/find'
+include { IRODS_FIND        } from '../../../modules/local/irods/find'
 include { IRODS_GETMETADATA } from '../../../modules/local/irods/getmetadata'
-include { COMBINE_METADATA } from '../../../modules/local/combine_metadata/main'
+include { COMBINE_METADATA  } from '../../../modules/local/combine_metadata/main'
 
 
 def matchFilePatterns(path, patterns) {
@@ -8,14 +8,14 @@ def matchFilePatterns(path, patterns) {
 }
 
 def makeFastqPrefix(metadata_list) {
-    Map<String, List> cramDict = [:].withDefault { [] }
+    def cramDict = [:].withDefault { [] }
 
     def sortedMetadata = metadata_list.sort { m ->
         "${m.id_run}_${(m.lane ?: '1')}".toString()
     }
 
     sortedMetadata.each { meta ->
-        String runidLane = "${meta.id_run}_${(meta.lane ?: '1')}".toString()
+        def runidLane = "${meta.id_run}_${(meta.lane ?: '1')}".toString()
         cramDict[runidLane] << meta.tag_index
 
         def sampleName = meta.sample
@@ -81,6 +81,6 @@ workflow IRODS_FINDCRAMS {
         )
 
     emit:
-    metadata = COMBINE_METADATA.out.csv
+    metadata = COMBINE_METADATA.out.csv.flatten().first()
     versions = versions
 }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the workflow's metadata handling, error management, and process robustness. The main themes are improved CSV parsing, error handling, and process reliability.

**Metadata and CSV Handling Improvements:**

* Updated CSV parsing in `main.nf` to handle quoted fields and improved validation for required columns (`fastq_prefix` and `cram_path`) to prevent missing data errors.
* Changed the `--subset_sep` parameter in `collect_metadata.config` to use a comma instead of a semicolon, ensuring consistency with the CSV format.
* In the `IRODS_GETMETADATA` process, replaced double quotes with single quotes in metadata output to avoid issues with downstream parsing.
* In the `IRODS_FINDCRAMS` subworkflow, flattened and extracted the first element of the combined metadata output to simplify downstream usage.

**Error Handling and Process Robustness:**

* Increased the maximum number of retries for processes from 3 to 5, and added a conditional error strategy to ignore tasks after the final retry in `nextflow.config`.
* Refactored variable declarations in `makeFastqPrefix` for clarity and consistency.